### PR TITLE
fix alignment of default assignments (:=) after directional keyword (in, out, inout, buffer)

### DIFF
--- a/VHDLFormatter.js
+++ b/VHDLFormatter.js
@@ -518,11 +518,11 @@ function beautifyPortGenericBlock(block, result, settings, indent, mode) {
 exports.beautifyPortGenericBlock = beautifyPortGenericBlock;
 function AlignSigns(result, startIndex, endIndex, mode, alignComments = false) {
     AlignSign_(result, startIndex, endIndex, ":", mode);
+    AlignSign_(result, startIndex, endIndex, "direction", mode);
     AlignSign_(result, startIndex, endIndex, ":=", mode);
     AlignSign_(result, startIndex, endIndex, "<=", mode);
     AlignSign_(result, startIndex, endIndex, "=>", mode);
     AlignSign_(result, startIndex, endIndex, "<=", mode); // Another pass to align when a => b <= c
-    AlignSign_(result, startIndex, endIndex, "direction", mode);
     if (alignComments) {
         AlignSign_(result, startIndex, endIndex, "@_@comments", mode);
     }

--- a/VHDLFormatter.ts
+++ b/VHDLFormatter.ts
@@ -595,11 +595,11 @@ export function beautifyPortGenericBlock(block: CodeBlock, result: (FormattedLin
 
 export function AlignSigns(result: (FormattedLine | FormattedLine[])[], startIndex: number, endIndex: number, mode: string, alignComments: boolean = false) {
     AlignSign_(result, startIndex, endIndex, ":", mode);
+    AlignSign_(result, startIndex, endIndex, "direction", mode);
     AlignSign_(result, startIndex, endIndex, ":=", mode);
     AlignSign_(result, startIndex, endIndex, "<=", mode);
     AlignSign_(result, startIndex, endIndex, "=>", mode);
     AlignSign_(result, startIndex, endIndex, "<=", mode); // Another pass to align when a => b <= c
-    AlignSign_(result, startIndex, endIndex, "direction", mode);
     if (alignComments) {
         AlignSign_(result, startIndex, endIndex, "@_@comments", mode);
     }


### PR DESCRIPTION
Currently the alignment of the directional keywords happens after the alignment of defaults which causes the latter to become unaligned afterwards. To see this happening try formatting the following snippet:
 ```
entity test is
    port(
        foo : in std_logic    := 'X';
        bar : out std_logic   := 'X';
        baz : inout std_logic := 'X'
    );
end entity;
```

The change fixes the order of the alignment operations.